### PR TITLE
Update dynamic_routes_includer.py

### DIFF
--- a/fastapi_dynamic_routers/dynamic_routes_includer.py
+++ b/fastapi_dynamic_routers/dynamic_routes_includer.py
@@ -4,7 +4,7 @@ from fastapi import FastAPI
 
 
 class Routers:
-    def __init__(self, app: FastAPI, routes: list, prefix: str = '/v1/api/') -> None:
+    def __init__(self, app: FastAPI, routes: list, prefix: str = '/v1/api') -> None:
         self.app = app
         self.routes = routes
         self.prefix = prefix


### PR DESCRIPTION
AssertionError: A path prefix must not end with '/', as the routes will start with '/'

Removing the trailing '/' from the default allows defaults to be used.